### PR TITLE
package.json: make "main" a single js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,7 @@
   "bugs": {
     "url": "https://github.com/object505/tipso/issues/new"
   },
-  "main": [
-    "src/tipso.min.js",
-    "src/tipso.css"
-  ],
+  "main": "src/tipso.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/object505/tipso.git"


### PR DESCRIPTION
In package.json, the "main" field should be just the JavaScript entry point.

Please note that you'll need to bump the version number in order to publish the change to npm.  To do this, you can run the following commands:

```
npm version patch
npm publish
git push origin master
```

This will bump the version to `1.0.3`, tag the release, push to github, and publish to npm.  (If you aren't logged into npm, you may also have to run `npm adduser`.  If you've lost your password, you can reset it at http://npm.im/forgot)

Thanks!