### PR TITLE
Allow updates to settings to be false

### DIFF
--- a/src/tipso.js
+++ b/src/tipso.js
@@ -374,7 +374,7 @@
     },
     update: function(key, value) {
       var obj = this;
-      if (value) {
+      if (typeof(value) !== "undefined") {
         obj.settings[key] = value;
       } else {
         return obj.settings[key];


### PR DESCRIPTION
Any updates that are falsey don't pass this check i.e. `false`, "" or 0 - might be better to check if the value is undefined.
