### PR TITLE
Added options to control show events and hide events

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ To use css3 animation effects please include [Animate.css](http://daneden.github
 | onBeforeShow        | function(){} | Function to be executed before tipso is shown                                                                                      |
 | onShow              | function(){} | Function to be executed after tipso is shown                                                                                       |
 | onHide              | function(){} | Function to be executed after tipso is hidden                                                                                      |
+| showEvents          | 'mouseover'  | Array or space separated list of events that should trigger the tooltip to show                                                    |
+| hideEvents          | 'mouseout'   | Array or space separated list of events that should trigger the tooltip to hide                                                    |
 
 > Additionaly you can use `data-tipso` instead of the title attribute for the tooltip content ( set `useTitle: false` )
 

--- a/src/tipso.js
+++ b/src/tipso.js
@@ -46,7 +46,9 @@
       templateEngineFunc: null,         //A function that compiles and renders the content
       onBeforeShow      : null,
       onShow            : null,
-      onHide            : null
+      onHide            : null,
+      showEvents        : 'mouseover',  //The events that trigger the tooltip to be shown
+      hideEvents        : 'mouseout'    //The events that trigger the tooltip to be hidden
     };
 
   function Plugin(element, options) {
@@ -112,17 +114,29 @@
         $doc = this.doc;
       $e.addClass('tipso_style').removeAttr('title');
 
+      var showEvents = (typeof obj.settings.showEvents == 'object') ? obj.settings.showEvents : obj.settings.showEvents.split(' ');
+      for (var i in showEvents) {
+        showEvents[i] = String(showEvents[ i ] + '.' + pluginName).trim();
+      }
+      showEvents = showEvents.join( ' ' );
+      
+      var hideEvents = (typeof obj.settings.hideEvents == 'object') ? obj.settings.hideEvents : obj.settings.hideEvents.split(' ');
+      for (var i in hideEvents) {
+        hideEvents[i] = String(hideEvents[ i ] + '.' + pluginName).trim();
+      }
+      hideEvents = hideEvents.join( ' ' );
+
       if (obj.settings.tooltipHover) {
         var waitForHover = null,
             hoverHelper = null;
-        $e.on('mouseover' + '.' + pluginName, function() {
+        $e.on(showEvents, function() {
           clearTimeout(waitForHover);
           clearTimeout(hoverHelper);
           hoverHelper = setTimeout(function(){
             obj.show();
           }, 150);
         });
-        $e.on('mouseout' + '.' + pluginName, function() {
+        $e.on(hideEvents, function() {
           clearTimeout(waitForHover);
           clearTimeout(hoverHelper);
           waitForHover = setTimeout(function(){
@@ -143,10 +157,10 @@
         ;
         });
       } else {
-        $e.on('mouseover' + '.' + pluginName, function() {
+        $e.on(showEvents, function() {
           obj.show();
         });
-        $e.on('mouseout' + '.' + pluginName, function() {
+        $e.on(hideEvents, function() {
           obj.hide();
         });
       }


### PR DESCRIPTION
Have added a "showEvents" option and a "hideEvents" option, which default to 'mouseover' and 'mouseout' respectively.

The options can be a space-separated string of events, or an array of events, that trigger the tooltip to be shown or hidden.

Useful if you want a tooltip to show on an input element when the cursor is focused on it (e.g. on tablet devices where mouseover isn't traditionally possible.)

Example:

`$('.tipso').tipso({
  showEvents: 'mouseover focus',
  hideEvents: 'mouseout blur'
});`