### PR TITLE
Title Bars Hide if Undefined

### DIFF
--- a/src/tipso.js
+++ b/src/tipso.js
@@ -203,7 +203,8 @@
         }
         tipso_bubble.find('.tipso_title').css({
             background: obj.settings.titleBackground,
-            color: obj.settings.titleColor
+            color: obj.settings.titleColor,
+            display: typeof obj.titleContent() === "undefined" ? 'none' : 'block'
         });
         tipso_bubble.find('.tipso_content').html(obj.content());
         tipso_bubble.find('.tipso_title').html(obj.titleContent());


### PR DESCRIPTION
Fixed Title bar showing regardless of whether Title is specified

At the moment (for me anyway), if `titleContent:` isn't specified, it still shows the div `<div class="tipso_title"></div>` HTML on the tooltip, and with padding can make the tooltip look odd and top-heavy.

This now hides it if the titleContent is undefined.